### PR TITLE
CLI-509: Update templates to use individual AMI 

### DIFF
--- a/aws/DRVault-Single-Deployment.json
+++ b/aws/DRVault-Single-Deployment.json
@@ -1221,71 +1221,113 @@
             "us-east-1": {
                 "Vault": "ami-45f2643a",
                 "Components": "ami-0c0e9973",
+                "CPM": "ami-0c0e9973",
+                "PVWA": "ami-0c0e9973",
+                "PSM": "ami-0c0e9973",
                 "PSMP": "ami-a6f167d9"
             },
             "us-east-2": {
                 "Vault": "ami-239fa246",
                 "Components": "ami-57a29f32",
+                "CPM": "ami-57a29f32",
+                "PVWA": "ami-57a29f32",
+                "PSM": "ami-57a29f32",
                 "PSMP": "ami-6e9ea30b"
             },
             "us-west-1": {
                 "Vault": "ami-60213800",
                 "Components": "ami-4a342d2a",
+                "CPM": "ami-4a342d2a",
+                "PVWA": "ami-4a342d2a",
+                "PSM": "ami-4a342d2a",
                 "PSMP": "ami-c22f36a2"
             },
             "us-west-2": {
                 "Vault": "ami-a291e3da",
                 "Components": "ami-46b9cb3e",
+                "CPM": "ami-46b9cb3e",
+                "PVWA": "ami-46b9cb3e",
+                "PSM": "ami-46b9cb3e",
                 "PSMP": "ami-e796e49f"
             },
             "ca-central-1": {
                 "Vault": "ami-9550d0f1",
                 "Components": "ami-6f4bcb0b",
+                "CPM": "ami-6f4bcb0b",
+                "PVWA": "ami-6f4bcb0b",
+                "PSM": "ami-6f4bcb0b",
                 "PSMP": "ami-9250d0f6"
             },
-            "eu-west-1": {
+			"eu-west-1": {
                 "Vault": "ami-e0af9f99",
                 "Components": "ami-95b383ec",
+                "CPM": "ami-95b383ec",
+                "PVWA": "ami-95b383ec",
+                "PSM": "ami-95b383ec",
                 "PSMP": "ami-3faf9f46"
             },
-            "eu-central-1": {
+			"eu-central-1": {
                 "Vault": "ami-f9cae512",
                 "Components": "ami-7cf8d797",
+                "CPM": "ami-7cf8d797",
+                "PVWA": "ami-7cf8d797",
+                "PSM": "ami-7cf8d797",
                 "PSMP": "ami-acc8e747"
             },
             "eu-west-2": {
                 "Vault": "ami-f66a8891",
                 "Components": "ami-0ce70a6b",
+                "CPM": "ami-0ce70a6b",
+                "PVWA": "ami-0ce70a6b",
+                "PSM": "ami-0ce70a6b",
                 "PSMP": "ami-a99674ce"
             },
-            "ap-southeast-1": {
+			"ap-southeast-1": {
                 "Vault": "ami-556d5c29",
                 "Components": "ami-de7849a2",
+                "CPM": "ami-de7849a2",
+                "PVWA": "ami-de7849a2",
+                "PSM": "ami-de7849a2",
                 "PSMP": "ami-506d5c2c"
             },
-            "ap-southeast-2": {
+			"ap-southeast-2": {
                 "Vault": "ami-d18253b3",
                 "Components": "ami-f896479a",
+                "CPM": "ami-f896479a",
+                "PVWA": "ami-f896479a",
+                "PSM": "ami-f896479a",
                 "PSMP": "ami-b18150d3"
             },
-            "ap-northeast-2": {
+			"ap-northeast-2": {
                 "Vault": "ami-23b51d4d",
                 "Components": "ami-91bf17ff",
+                "CPM": "ami-91bf17ff",
+                "PVWA": "ami-91bf17ff",
+                "PSM": "ami-91bf17ff",
                 "PSMP": "ami-d9b119b7"
             },
-            "ap-northeast-1": {
+			"ap-northeast-1": {
                 "Vault": "ami-ac17e0d3",
                 "Components": "ami-a327d0dc",
+                "CPM": "ami-a327d0dc",
+                "PVWA": "ami-a327d0dc",
+                "PSM": "ami-a327d0dc",
                 "PSMP": "ami-982adde7"
             },
             "ap-south-1": {
                 "Vault": "ami-676d4008",
                 "Components": "ami-7795b718",
+                "CPM": "ami-7795b718",
+                "PVWA": "ami-7795b718",
+                "PSM": "ami-7795b718",
                 "PSMP": "ami-776c4118"
             },
             "sa-east-1": {
                 "Vault": "ami-96b7ebfa",
                 "Components": "ami-0e87db62",
+                "CPM": "ami-0e87db62",
+                "PVWA": "ami-0e87db62",
+                "PSM": "ami-0e87db62",
                 "PSMP": "ami-fdb4e891"
             }
         }

--- a/aws/Full-PAS-Deployment.json
+++ b/aws/Full-PAS-Deployment.json
@@ -1208,7 +1208,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "Components"
+                        "CPM"
                     ]
                 },
                 "InstanceType": {
@@ -1510,7 +1510,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "Components"
+                        "PVWA"
                     ]
                 },
                 "InstanceType": {
@@ -1807,7 +1807,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "Components"
+                        "PSM"
                     ]
                 },
                 "InstanceType": {
@@ -3038,71 +3038,113 @@
             "us-east-1": {
                 "Vault": "ami-45f2643a",
                 "Components": "ami-0c0e9973",
+                "CPM": "ami-0c0e9973",
+                "PVWA": "ami-0c0e9973",
+                "PSM": "ami-0c0e9973",
                 "PSMP": "ami-a6f167d9"
             },
             "us-east-2": {
                 "Vault": "ami-239fa246",
                 "Components": "ami-57a29f32",
+                "CPM": "ami-57a29f32",
+                "PVWA": "ami-57a29f32",
+                "PSM": "ami-57a29f32",
                 "PSMP": "ami-6e9ea30b"
             },
             "us-west-1": {
                 "Vault": "ami-60213800",
                 "Components": "ami-4a342d2a",
+                "CPM": "ami-4a342d2a",
+                "PVWA": "ami-4a342d2a",
+                "PSM": "ami-4a342d2a",
                 "PSMP": "ami-c22f36a2"
             },
             "us-west-2": {
                 "Vault": "ami-a291e3da",
                 "Components": "ami-46b9cb3e",
+                "CPM": "ami-46b9cb3e",
+                "PVWA": "ami-46b9cb3e",
+                "PSM": "ami-46b9cb3e",
                 "PSMP": "ami-e796e49f"
             },
             "ca-central-1": {
                 "Vault": "ami-9550d0f1",
                 "Components": "ami-6f4bcb0b",
+                "CPM": "ami-6f4bcb0b",
+                "PVWA": "ami-6f4bcb0b",
+                "PSM": "ami-6f4bcb0b",
                 "PSMP": "ami-9250d0f6"
             },
 			"eu-west-1": {
                 "Vault": "ami-e0af9f99",
                 "Components": "ami-95b383ec",
+                "CPM": "ami-95b383ec",
+                "PVWA": "ami-95b383ec",
+                "PSM": "ami-95b383ec",
                 "PSMP": "ami-3faf9f46"
             },
 			"eu-central-1": {
                 "Vault": "ami-f9cae512",
                 "Components": "ami-7cf8d797",
+                "CPM": "ami-7cf8d797",
+                "PVWA": "ami-7cf8d797",
+                "PSM": "ami-7cf8d797",
                 "PSMP": "ami-acc8e747"
             },
             "eu-west-2": {
                 "Vault": "ami-f66a8891",
                 "Components": "ami-0ce70a6b",
+                "CPM": "ami-0ce70a6b",
+                "PVWA": "ami-0ce70a6b",
+                "PSM": "ami-0ce70a6b",
                 "PSMP": "ami-a99674ce"
             },
 			"ap-southeast-1": {
                 "Vault": "ami-556d5c29",
                 "Components": "ami-de7849a2",
+                "CPM": "ami-de7849a2",
+                "PVWA": "ami-de7849a2",
+                "PSM": "ami-de7849a2",
                 "PSMP": "ami-506d5c2c"
             },
 			"ap-southeast-2": {
                 "Vault": "ami-d18253b3",
                 "Components": "ami-f896479a",
+                "CPM": "ami-f896479a",
+                "PVWA": "ami-f896479a",
+                "PSM": "ami-f896479a",
                 "PSMP": "ami-b18150d3"
             },
 			"ap-northeast-2": {
                 "Vault": "ami-23b51d4d",
                 "Components": "ami-91bf17ff",
+                "CPM": "ami-91bf17ff",
+                "PVWA": "ami-91bf17ff",
+                "PSM": "ami-91bf17ff",
                 "PSMP": "ami-d9b119b7"
             },
 			"ap-northeast-1": {
                 "Vault": "ami-ac17e0d3",
                 "Components": "ami-a327d0dc",
+                "CPM": "ami-a327d0dc",
+                "PVWA": "ami-a327d0dc",
+                "PSM": "ami-a327d0dc",
                 "PSMP": "ami-982adde7"
             },
             "ap-south-1": {
                 "Vault": "ami-676d4008",
                 "Components": "ami-7795b718",
+                "CPM": "ami-7795b718",
+                "PVWA": "ami-7795b718",
+                "PSM": "ami-7795b718",
                 "PSMP": "ami-776c4118"
             },
             "sa-east-1": {
                 "Vault": "ami-96b7ebfa",
                 "Components": "ami-0e87db62",
+                "CPM": "ami-0e87db62",
+                "PVWA": "ami-0e87db62",
+                "PSM": "ami-0e87db62",
                 "PSMP": "ami-fdb4e891"
             }
         }     

--- a/aws/PAS-AIO-dr-Deployment.json
+++ b/aws/PAS-AIO-dr-Deployment.json
@@ -2172,59 +2172,115 @@
         "RegionMap": {
             "us-east-1": {
                 "Vault": "ami-45f2643a",
-                "Components": "ami-0c0e9973"
+                "Components": "ami-0c0e9973",
+                "CPM": "ami-0c0e9973",
+                "PVWA": "ami-0c0e9973",
+                "PSM": "ami-0c0e9973",
+                "PSMP": "ami-a6f167d9"
             },
             "us-east-2": {
                 "Vault": "ami-239fa246",
-                "Components": "ami-57a29f32"
+                "Components": "ami-57a29f32",
+                "CPM": "ami-57a29f32",
+                "PVWA": "ami-57a29f32",
+                "PSM": "ami-57a29f32",
+                "PSMP": "ami-6e9ea30b"
             },
             "us-west-1": {
                 "Vault": "ami-60213800",
-                "Components": "ami-4a342d2a"
+                "Components": "ami-4a342d2a",
+                "CPM": "ami-4a342d2a",
+                "PVWA": "ami-4a342d2a",
+                "PSM": "ami-4a342d2a",
+                "PSMP": "ami-c22f36a2"
             },
             "us-west-2": {
                 "Vault": "ami-a291e3da",
-                "Components": "ami-46b9cb3e"
+                "Components": "ami-46b9cb3e",
+                "CPM": "ami-46b9cb3e",
+                "PVWA": "ami-46b9cb3e",
+                "PSM": "ami-46b9cb3e",
+                "PSMP": "ami-e796e49f"
             },
             "ca-central-1": {
                 "Vault": "ami-9550d0f1",
-                "Components": "ami-6f4bcb0b"
+                "Components": "ami-6f4bcb0b",
+                "CPM": "ami-6f4bcb0b",
+                "PVWA": "ami-6f4bcb0b",
+                "PSM": "ami-6f4bcb0b",
+                "PSMP": "ami-9250d0f6"
             },
 			"eu-west-1": {
                 "Vault": "ami-e0af9f99",
-                "Components": "ami-95b383ec"
+                "Components": "ami-95b383ec",
+                "CPM": "ami-95b383ec",
+                "PVWA": "ami-95b383ec",
+                "PSM": "ami-95b383ec",
+                "PSMP": "ami-3faf9f46"
             },
 			"eu-central-1": {
                 "Vault": "ami-f9cae512",
-                "Components": "ami-7cf8d797"
+                "Components": "ami-7cf8d797",
+                "CPM": "ami-7cf8d797",
+                "PVWA": "ami-7cf8d797",
+                "PSM": "ami-7cf8d797",
+                "PSMP": "ami-acc8e747"
             },
             "eu-west-2": {
                 "Vault": "ami-f66a8891",
-                "Components": "ami-0ce70a6b"
+                "Components": "ami-0ce70a6b",
+                "CPM": "ami-0ce70a6b",
+                "PVWA": "ami-0ce70a6b",
+                "PSM": "ami-0ce70a6b",
+                "PSMP": "ami-a99674ce"
             },
 			"ap-southeast-1": {
                 "Vault": "ami-556d5c29",
-                "Components": "ami-de7849a2"
+                "Components": "ami-de7849a2",
+                "CPM": "ami-de7849a2",
+                "PVWA": "ami-de7849a2",
+                "PSM": "ami-de7849a2",
+                "PSMP": "ami-506d5c2c"
             },
 			"ap-southeast-2": {
                 "Vault": "ami-d18253b3",
-                "Components": "ami-f896479a"
+                "Components": "ami-f896479a",
+                "CPM": "ami-f896479a",
+                "PVWA": "ami-f896479a",
+                "PSM": "ami-f896479a",
+                "PSMP": "ami-b18150d3"
             },
 			"ap-northeast-2": {
                 "Vault": "ami-23b51d4d",
-                "Components": "ami-91bf17ff"
+                "Components": "ami-91bf17ff",
+                "CPM": "ami-91bf17ff",
+                "PVWA": "ami-91bf17ff",
+                "PSM": "ami-91bf17ff",
+                "PSMP": "ami-d9b119b7"
             },
 			"ap-northeast-1": {
                 "Vault": "ami-ac17e0d3",
-                "Components": "ami-a327d0dc"
+                "Components": "ami-a327d0dc",
+                "CPM": "ami-a327d0dc",
+                "PVWA": "ami-a327d0dc",
+                "PSM": "ami-a327d0dc",
+                "PSMP": "ami-982adde7"
             },
             "ap-south-1": {
                 "Vault": "ami-676d4008",
-                "Components": "ami-7795b718"
+                "Components": "ami-7795b718",
+                "CPM": "ami-7795b718",
+                "PVWA": "ami-7795b718",
+                "PSM": "ami-7795b718",
+                "PSMP": "ami-776c4118"
             },
             "sa-east-1": {
                 "Vault": "ami-96b7ebfa",
-                "Components": "ami-0e87db62"
+                "Components": "ami-0e87db62",
+                "CPM": "ami-0e87db62",
+                "PVWA": "ami-0e87db62",
+                "PSM": "ami-0e87db62",
+                "PSMP": "ami-fdb4e891"
             }
         }  
     },

--- a/aws/PAS-AIO-template.json
+++ b/aws/PAS-AIO-template.json
@@ -1656,61 +1656,117 @@
         "RegionMap": {
             "us-east-1": {
                 "Vault": "ami-45f2643a",
-                "Components": "ami-0c0e9973"
+                "Components": "ami-0c0e9973",
+                "CPM": "ami-0c0e9973",
+                "PVWA": "ami-0c0e9973",
+                "PSM": "ami-0c0e9973",
+                "PSMP": "ami-a6f167d9"
             },
             "us-east-2": {
                 "Vault": "ami-239fa246",
-                "Components": "ami-57a29f32"
+                "Components": "ami-57a29f32",
+                "CPM": "ami-57a29f32",
+                "PVWA": "ami-57a29f32",
+                "PSM": "ami-57a29f32",
+                "PSMP": "ami-6e9ea30b"
             },
             "us-west-1": {
                 "Vault": "ami-60213800",
-                "Components": "ami-4a342d2a"
+                "Components": "ami-4a342d2a",
+                "CPM": "ami-4a342d2a",
+                "PVWA": "ami-4a342d2a",
+                "PSM": "ami-4a342d2a",
+                "PSMP": "ami-c22f36a2"
             },
             "us-west-2": {
                 "Vault": "ami-a291e3da",
-                "Components": "ami-46b9cb3e"
+                "Components": "ami-46b9cb3e",
+                "CPM": "ami-46b9cb3e",
+                "PVWA": "ami-46b9cb3e",
+                "PSM": "ami-46b9cb3e",
+                "PSMP": "ami-e796e49f"
             },
             "ca-central-1": {
                 "Vault": "ami-9550d0f1",
-                "Components": "ami-6f4bcb0b"
+                "Components": "ami-6f4bcb0b",
+                "CPM": "ami-6f4bcb0b",
+                "PVWA": "ami-6f4bcb0b",
+                "PSM": "ami-6f4bcb0b",
+                "PSMP": "ami-9250d0f6"
             },
 			"eu-west-1": {
                 "Vault": "ami-e0af9f99",
-                "Components": "ami-95b383ec"
+                "Components": "ami-95b383ec",
+                "CPM": "ami-95b383ec",
+                "PVWA": "ami-95b383ec",
+                "PSM": "ami-95b383ec",
+                "PSMP": "ami-3faf9f46"
             },
 			"eu-central-1": {
                 "Vault": "ami-f9cae512",
-                "Components": "ami-7cf8d797"
+                "Components": "ami-7cf8d797",
+                "CPM": "ami-7cf8d797",
+                "PVWA": "ami-7cf8d797",
+                "PSM": "ami-7cf8d797",
+                "PSMP": "ami-acc8e747"
             },
             "eu-west-2": {
                 "Vault": "ami-f66a8891",
-                "Components": "ami-0ce70a6b"
+                "Components": "ami-0ce70a6b",
+                "CPM": "ami-0ce70a6b",
+                "PVWA": "ami-0ce70a6b",
+                "PSM": "ami-0ce70a6b",
+                "PSMP": "ami-a99674ce"
             },
 			"ap-southeast-1": {
                 "Vault": "ami-556d5c29",
-                "Components": "ami-de7849a2"
+                "Components": "ami-de7849a2",
+                "CPM": "ami-de7849a2",
+                "PVWA": "ami-de7849a2",
+                "PSM": "ami-de7849a2",
+                "PSMP": "ami-506d5c2c"
             },
 			"ap-southeast-2": {
                 "Vault": "ami-d18253b3",
-                "Components": "ami-f896479a"
+                "Components": "ami-f896479a",
+                "CPM": "ami-f896479a",
+                "PVWA": "ami-f896479a",
+                "PSM": "ami-f896479a",
+                "PSMP": "ami-b18150d3"
             },
 			"ap-northeast-2": {
                 "Vault": "ami-23b51d4d",
-                "Components": "ami-91bf17ff"
+                "Components": "ami-91bf17ff",
+                "CPM": "ami-91bf17ff",
+                "PVWA": "ami-91bf17ff",
+                "PSM": "ami-91bf17ff",
+                "PSMP": "ami-d9b119b7"
             },
 			"ap-northeast-1": {
                 "Vault": "ami-ac17e0d3",
-                "Components": "ami-a327d0dc"
+                "Components": "ami-a327d0dc",
+                "CPM": "ami-a327d0dc",
+                "PVWA": "ami-a327d0dc",
+                "PSM": "ami-a327d0dc",
+                "PSMP": "ami-982adde7"
             },
             "ap-south-1": {
                 "Vault": "ami-676d4008",
-                "Components": "ami-7795b718"
+                "Components": "ami-7795b718",
+                "CPM": "ami-7795b718",
+                "PVWA": "ami-7795b718",
+                "PSM": "ami-7795b718",
+                "PSMP": "ami-776c4118"
             },
             "sa-east-1": {
                 "Vault": "ami-96b7ebfa",
-                "Components": "ami-0e87db62"
+                "Components": "ami-0e87db62",
+                "CPM": "ami-0e87db62",
+                "PVWA": "ami-0e87db62",
+                "PSM": "ami-0e87db62",
+                "PSMP": "ami-fdb4e891"
             }
-        } 
+        }
     },
     "Outputs": {
         "CloudWatchLogGroupName": {

--- a/aws/PAS-Component-Single-Deployment.json
+++ b/aws/PAS-Component-Single-Deployment.json
@@ -468,7 +468,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "Components"
+                        "CPM"
                     ]
                 },
                 "InstanceType": {
@@ -801,7 +801,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "Components"
+                        "PVWA"
                     ]
                 },
                 "InstanceType": {
@@ -1130,7 +1130,7 @@
                         {
                             "Ref": "AWS::Region"
                         },
-                        "Components"
+                        "PSM"
                     ]
                 },
                 "InstanceType": {
@@ -2232,71 +2232,113 @@
             "us-east-1": {
                 "Vault": "ami-45f2643a",
                 "Components": "ami-0c0e9973",
+                "CPM": "ami-0c0e9973",
+                "PVWA": "ami-0c0e9973",
+                "PSM": "ami-0c0e9973",
                 "PSMP": "ami-a6f167d9"
             },
             "us-east-2": {
                 "Vault": "ami-239fa246",
                 "Components": "ami-57a29f32",
+                "CPM": "ami-57a29f32",
+                "PVWA": "ami-57a29f32",
+                "PSM": "ami-57a29f32",
                 "PSMP": "ami-6e9ea30b"
             },
             "us-west-1": {
                 "Vault": "ami-60213800",
                 "Components": "ami-4a342d2a",
+                "CPM": "ami-4a342d2a",
+                "PVWA": "ami-4a342d2a",
+                "PSM": "ami-4a342d2a",
                 "PSMP": "ami-c22f36a2"
             },
             "us-west-2": {
                 "Vault": "ami-a291e3da",
                 "Components": "ami-46b9cb3e",
+                "CPM": "ami-46b9cb3e",
+                "PVWA": "ami-46b9cb3e",
+                "PSM": "ami-46b9cb3e",
                 "PSMP": "ami-e796e49f"
             },
             "ca-central-1": {
                 "Vault": "ami-9550d0f1",
                 "Components": "ami-6f4bcb0b",
+                "CPM": "ami-6f4bcb0b",
+                "PVWA": "ami-6f4bcb0b",
+                "PSM": "ami-6f4bcb0b",
                 "PSMP": "ami-9250d0f6"
             },
-            "eu-west-1": {
+			"eu-west-1": {
                 "Vault": "ami-e0af9f99",
                 "Components": "ami-95b383ec",
+                "CPM": "ami-95b383ec",
+                "PVWA": "ami-95b383ec",
+                "PSM": "ami-95b383ec",
                 "PSMP": "ami-3faf9f46"
             },
-            "eu-central-1": {
+			"eu-central-1": {
                 "Vault": "ami-f9cae512",
                 "Components": "ami-7cf8d797",
+                "CPM": "ami-7cf8d797",
+                "PVWA": "ami-7cf8d797",
+                "PSM": "ami-7cf8d797",
                 "PSMP": "ami-acc8e747"
             },
             "eu-west-2": {
                 "Vault": "ami-f66a8891",
                 "Components": "ami-0ce70a6b",
+                "CPM": "ami-0ce70a6b",
+                "PVWA": "ami-0ce70a6b",
+                "PSM": "ami-0ce70a6b",
                 "PSMP": "ami-a99674ce"
             },
-            "ap-southeast-1": {
+			"ap-southeast-1": {
                 "Vault": "ami-556d5c29",
                 "Components": "ami-de7849a2",
+                "CPM": "ami-de7849a2",
+                "PVWA": "ami-de7849a2",
+                "PSM": "ami-de7849a2",
                 "PSMP": "ami-506d5c2c"
             },
-            "ap-southeast-2": {
+			"ap-southeast-2": {
                 "Vault": "ami-d18253b3",
                 "Components": "ami-f896479a",
+                "CPM": "ami-f896479a",
+                "PVWA": "ami-f896479a",
+                "PSM": "ami-f896479a",
                 "PSMP": "ami-b18150d3"
             },
-            "ap-northeast-2": {
+			"ap-northeast-2": {
                 "Vault": "ami-23b51d4d",
                 "Components": "ami-91bf17ff",
+                "CPM": "ami-91bf17ff",
+                "PVWA": "ami-91bf17ff",
+                "PSM": "ami-91bf17ff",
                 "PSMP": "ami-d9b119b7"
             },
-            "ap-northeast-1": {
+			"ap-northeast-1": {
                 "Vault": "ami-ac17e0d3",
                 "Components": "ami-a327d0dc",
+                "CPM": "ami-a327d0dc",
+                "PVWA": "ami-a327d0dc",
+                "PSM": "ami-a327d0dc",
                 "PSMP": "ami-982adde7"
             },
             "ap-south-1": {
                 "Vault": "ami-676d4008",
                 "Components": "ami-7795b718",
+                "CPM": "ami-7795b718",
+                "PVWA": "ami-7795b718",
+                "PSM": "ami-7795b718",
                 "PSMP": "ami-776c4118"
             },
             "sa-east-1": {
                 "Vault": "ami-96b7ebfa",
                 "Components": "ami-0e87db62",
+                "CPM": "ami-0e87db62",
+                "PVWA": "ami-0e87db62",
+                "PSM": "ami-0e87db62",
                 "PSMP": "ami-fdb4e891"
             }
         }

--- a/aws/Vault-Single-Deployment.json
+++ b/aws/Vault-Single-Deployment.json
@@ -1212,71 +1212,113 @@
             "us-east-1": {
                 "Vault": "ami-45f2643a",
                 "Components": "ami-0c0e9973",
+                "CPM": "ami-0c0e9973",
+                "PVWA": "ami-0c0e9973",
+                "PSM": "ami-0c0e9973",
                 "PSMP": "ami-a6f167d9"
             },
             "us-east-2": {
                 "Vault": "ami-239fa246",
                 "Components": "ami-57a29f32",
+                "CPM": "ami-57a29f32",
+                "PVWA": "ami-57a29f32",
+                "PSM": "ami-57a29f32",
                 "PSMP": "ami-6e9ea30b"
             },
             "us-west-1": {
                 "Vault": "ami-60213800",
                 "Components": "ami-4a342d2a",
+                "CPM": "ami-4a342d2a",
+                "PVWA": "ami-4a342d2a",
+                "PSM": "ami-4a342d2a",
                 "PSMP": "ami-c22f36a2"
             },
             "us-west-2": {
                 "Vault": "ami-a291e3da",
                 "Components": "ami-46b9cb3e",
+                "CPM": "ami-46b9cb3e",
+                "PVWA": "ami-46b9cb3e",
+                "PSM": "ami-46b9cb3e",
                 "PSMP": "ami-e796e49f"
             },
             "ca-central-1": {
                 "Vault": "ami-9550d0f1",
                 "Components": "ami-6f4bcb0b",
+                "CPM": "ami-6f4bcb0b",
+                "PVWA": "ami-6f4bcb0b",
+                "PSM": "ami-6f4bcb0b",
                 "PSMP": "ami-9250d0f6"
             },
-            "eu-west-1": {
+			"eu-west-1": {
                 "Vault": "ami-e0af9f99",
                 "Components": "ami-95b383ec",
+                "CPM": "ami-95b383ec",
+                "PVWA": "ami-95b383ec",
+                "PSM": "ami-95b383ec",
                 "PSMP": "ami-3faf9f46"
             },
-            "eu-central-1": {
+			"eu-central-1": {
                 "Vault": "ami-f9cae512",
                 "Components": "ami-7cf8d797",
+                "CPM": "ami-7cf8d797",
+                "PVWA": "ami-7cf8d797",
+                "PSM": "ami-7cf8d797",
                 "PSMP": "ami-acc8e747"
             },
             "eu-west-2": {
                 "Vault": "ami-f66a8891",
                 "Components": "ami-0ce70a6b",
+                "CPM": "ami-0ce70a6b",
+                "PVWA": "ami-0ce70a6b",
+                "PSM": "ami-0ce70a6b",
                 "PSMP": "ami-a99674ce"
             },
-            "ap-southeast-1": {
+			"ap-southeast-1": {
                 "Vault": "ami-556d5c29",
                 "Components": "ami-de7849a2",
+                "CPM": "ami-de7849a2",
+                "PVWA": "ami-de7849a2",
+                "PSM": "ami-de7849a2",
                 "PSMP": "ami-506d5c2c"
             },
-            "ap-southeast-2": {
+			"ap-southeast-2": {
                 "Vault": "ami-d18253b3",
                 "Components": "ami-f896479a",
+                "CPM": "ami-f896479a",
+                "PVWA": "ami-f896479a",
+                "PSM": "ami-f896479a",
                 "PSMP": "ami-b18150d3"
             },
-            "ap-northeast-2": {
+			"ap-northeast-2": {
                 "Vault": "ami-23b51d4d",
                 "Components": "ami-91bf17ff",
+                "CPM": "ami-91bf17ff",
+                "PVWA": "ami-91bf17ff",
+                "PSM": "ami-91bf17ff",
                 "PSMP": "ami-d9b119b7"
             },
-            "ap-northeast-1": {
+			"ap-northeast-1": {
                 "Vault": "ami-ac17e0d3",
                 "Components": "ami-a327d0dc",
+                "CPM": "ami-a327d0dc",
+                "PVWA": "ami-a327d0dc",
+                "PSM": "ami-a327d0dc",
                 "PSMP": "ami-982adde7"
             },
             "ap-south-1": {
                 "Vault": "ami-676d4008",
                 "Components": "ami-7795b718",
+                "CPM": "ami-7795b718",
+                "PVWA": "ami-7795b718",
+                "PSM": "ami-7795b718",
                 "PSMP": "ami-776c4118"
             },
             "sa-east-1": {
                 "Vault": "ami-96b7ebfa",
                 "Components": "ami-0e87db62",
+                "CPM": "ami-0e87db62",
+                "PVWA": "ami-0e87db62",
+                "PSM": "ami-0e87db62",
                 "PSMP": "ami-fdb4e891"
             }
         }


### PR DESCRIPTION
All templates have been updated to point to single components ami id according to the component