### PR TITLE
fix DRVault VMName

### DIFF
--- a/azure/pas-dr-deploy.json
+++ b/azure/pas-dr-deploy.json
@@ -42,7 +42,7 @@
             }
         },
         "DR Vault VM Name": {
-            "defaultValue": "CyberArk DR Vault",
+            "defaultValue": "DRVault",
 	    "type": "String",
             "metadata": {
                 "description": "Enter a name for the DR Vault VM."


### PR DESCRIPTION
Fixed #264 

I changed it because the VM name with spaces always fails to deploy.