### PR TITLE
Update PTA-Single-Deployment.json

### DIFF
--- a/aws/pta/PTA-Single-Deployment.json
+++ b/aws/pta/PTA-Single-Deployment.json
@@ -157,23 +157,23 @@
                         "        physicalResourceId = event['PhysicalResourceId']",
                         "",
                         "    if 'Password' not in event['ResourceProperties'] or not event['ResourceProperties']['Password']:",
-                        "            print 'The property Password must not be empty'",
+                        "            print('The property Password must not be empty')",
                         "            return cfnresponse.send(event, context, cfnresponse.FAILED, {}, physicalResourceId)",
                         "",
                         "    try:",
                         "        if event['RequestType'] == 'Delete':",
                         "            deletePassword(physicalResourceId)",
-                        "            print 'Password successfully deleted. Id='+physicalResourceId",
+                        "            print('Password successfully deleted. Id='+physicalResourceId)",
                         "            return cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId)",
                         "",
                         "        if event['RequestType'] == 'Create':",
                         "            storePassword(physicalResourceId, event['ResourceProperties']['Password'])",
-                        "            print 'The store parameter has been created. Id='+physicalResourceId",
+                        "            print('The store parameter has been created. Id='+physicalResourceId)",
                         "            response = { 'SsmId': physicalResourceId }",
                         "            return cfnresponse.send(event, context, cfnresponse.SUCCESS, response, physicalResourceId)",
                         "",
                         "    except client.exceptions.ParameterNotFound:",
-                        "        print 'Item already removed'",
+                        "        print('Item already removed')",
                         "        return cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId)",
                         "    except Exception as E:",
                         "        print E",
@@ -182,7 +182,7 @@
                   ]
                }
             },
-            "Runtime":"python2.7",
+            "Runtime":"python3.7",
             "Handler":"index.lambda_handler",
             "Role":{
                "Fn::GetAtt":[
@@ -221,22 +221,22 @@
                         "    try:",
                         "        if event['RequestType'] == 'Create':",
                         "            deletePassword(event['ResourceProperties']['key'])",
-                        "            print 'Password succesfully deleted. Id='+event['ResourceProperties']['key']",
+                        "            print('Password succesfully deleted. Id='+event['ResourceProperties']['key'])",
                         "            return cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId)",
                         "        if event['RequestType'] == 'Delete':",
                         "            return cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId)",
                         "",
                         "    except client.exceptions.ParameterNotFound:",
-                        "        print 'Item already removed'",
+                        "        print('Item already removed')",
                         "        return cfnresponse.send(event, context, cfnresponse.SUCCESS, {}, physicalResourceId)",
                         "    except Exception as E:",
-                        "        print E",
+                        "        print(E)",
                         "        return cfnresponse.send(event, context, cfnresponse.FAILED, {}, physicalResourceId)"
                      ]
                   ]
                }
             },
-            "Runtime":"python2.7",
+            "Runtime":"python3.7",
             "Handler":"index.lambda_handler",
             "Role":{
                "Fn::GetAtt":[


### PR DESCRIPTION
AWS appears to have deprecated Python 2.7 and the PTA template will not allow you to proceed as provided. Updated PTA template to match the Python version in other templates and made small syntax changes to the print function to reflect the update.

### Desired Outcome

Launching the PTA-Single-Deployment Cfn template will successfully create the expected resources. Currently, the stack fails near the very beginning and does not create any usable resources.

### Implemented Changes

Simple syntax changes allow the Cfn template to create all resources, but still throws an error. Disabling rollback on the stack will leave a user with functional resources. The underlying AMI should also be updated to use a non-deprecated version of Python to eliminate the remaining error.

### Connected Issue/Story

N/A

### Definition of Done

#### Changelog

- [ ] The CHANGELOG has been updated, or
- [x] This PR does not include user-facing changes and doesn't require a
  CHANGELOG update

#### Test coverage

- [ ] This PR includes new unit and integration tests to go with the code
  changes, or
- [X] The changes in this PR do not require tests

#### Documentation

- [ ] Docs (e.g. `README`s) were updated in this PR
- [ ] A follow-up issue to update official docs has been filed here: [insert issue ID]()
- [X] This PR does not require updating any documentation

#### Behavior

- [ ] This PR changes product behavior and has been reviewed by a PO, or
- [ ] These changes are part of a larger initiative that will be reviewed later, or
- [X] No behavior was changed with this PR

#### Security

- [ ] Security architect has reviewed the changes in this PR,
- [ ] These changes are part of a larger initiative with a separate security review, or
- [X] There are no security aspects to these changes 
