### PR TITLE
Updating Allowed template values

### DIFF
--- a/aws/PTA-Single-Deployment.yaml
+++ b/aws/PTA-Single-Deployment.yaml
@@ -359,9 +359,9 @@ Parameters:
     Type: String
     Description: Select the instance type of the PTA instance.
     AllowedValues:
-      - m6i.2xlarge
-      - m6i.4xlarge
-    Default: m6i.2xlarge
+      - m5.2xlarge
+      - m5.4xlarge
+    Default: m5.2xlarge
   PTAInstanceSecurityGroups:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
     Description: Assign Security Groups to the PTA instance.

--- a/aws/PTA-Single-Deployment.yaml
+++ b/aws/PTA-Single-Deployment.yaml
@@ -359,9 +359,9 @@ Parameters:
     Type: String
     Description: Select the instance type of the PTA instance.
     AllowedValues:
-      - m4.2xlarge
-      - m4.4xlarge
-    Default: m4.2xlarge
+      - m6i.2xlarge
+      - m6i.4xlarge
+    Default: m6i.2xlarge
   PTAInstanceSecurityGroups:
     Type: 'List<AWS::EC2::SecurityGroup::Id>'
     Description: Assign Security Groups to the PTA instance.


### PR DESCRIPTION
Our template states we need an M4 instance, however our documentation states we recommend a T3 instance.

Reviewing this in full, it looks like the most appropriate current-gen solution would be the M5 line
M5 is cheaper and faster than M4
I am recommending the same sized machines, just 1 generation above M4
https://aws.amazon.com/ec2/instance-types/
