### PR TITLE
Update DRVault-Single-Deployment.yaml 

### DIFF
--- a/aws/DRVault-Single-Deployment.yaml
+++ b/aws/DRVault-Single-Deployment.yaml
@@ -432,10 +432,9 @@ Parameters:
     Type: String
     Description: Enter the secret string for the DR user that was set on the Primary Vault.(Optional).
     NoEcho: true
-    AllowedPattern: ^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[~!?@#$%^&\*\(\)_\-+=:])(?=\S+$).{8,}$|.{0,0}
+    AllowedPattern: ^$|^(?=.*[0-9])(?=.*[a-z])(?=.*[A-Z])(?=.*[~!?@#$%^&\*\(\)_\-+=:])(?=\S+$).{10,}$
     ConstraintDescription: if the value isnt empty it must contain at least 1 lowercase letter, 1 uppercase letter, 1 digit and 1 special characters,
       Minimum 10 characters, Allowed A-Z,a-z,0-9,all special characters, Cannot except / \ - ; and controlled characters.
-    MinLength: 10
   VaultInstanceName:
     Type: String
     Description: Enter a name for the DR Vault instance.


### PR DESCRIPTION
Update DRVault-Single-Deployment.yaml

Fix - In the "Secret" parameters - Secret String for the DR user is supposed to be "Optional" and is not because "MinLength: 10"

* Remove "MinLength: 10" which makes the "Secret" required.
* Edit the AllowedPattern to check for the 10 character min length.